### PR TITLE
Add basic i18n for generator responses

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -5,6 +5,8 @@
 
 # 使用本项目API需要填写的key
 API_KEY=sk-1
+# 输出语言: zh 或 en
+APP_LANG=zh
 
 # 只填入Gemini即可使用! 基础与总结模型使用2.5pro,评估和压缩使用2.5flash 具体模型配置优先级高于此默认值
 ALL_IN_GEMINI_KEY='Asahj-EmD7V8DWq4sA4fkYIYyquBwuFzs,bnFEmD7-sA4fkYIYyquBFzs'

--- a/app/chat/chat_summary.py
+++ b/app/chat/chat_summary.py
@@ -13,6 +13,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.append(str(ROOT_DIR))
 
 from app.utils.tools import sse_create_openai_data, sse_gemini2openai_data
+from app.utils.i18n import i18n
 from config.base_config import SUMMARY_API_KEY,SUMMARY_API_URL,SUMMARY_MODEL,SUMMARY_API_TYPE
 from config.logging_config import logger
 
@@ -53,7 +54,7 @@ def openai_stream_no(messages:list[dict], model:str = SUMMARY_MODEL):
             if retry_count >= MAX_RETRIES:
                 logger.error(f"json_data: {completion.model_dump_json()}")
                 logger.error(f"{model}请求失败: {str(e)}")
-                return "请求失败"
+                return i18n('request_failed')
             else:
                 logger.warning(f"{model}请求失败: {str(e)} 正在重试{retry_count}")
 
@@ -95,7 +96,7 @@ def openai_stream_yes(messages: list[dict], model: str = SUMMARY_MODEL):
             retry_count += 1
             if retry_count >= MAX_RETRIES:
                 logger.error(f"{model}请求失败: {str(e)}")
-                yield "请求失败"
+                yield i18n('request_failed')
                 return
             else:
                 logger.warning(f"{model}请求失败: {str(e)} 正在重试{retry_count}")

--- a/app/chat/functions.py
+++ b/app/chat/functions.py
@@ -13,6 +13,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.append(str(ROOT_DIR))
 
 from app.utils.tools import sse_create_openai_data, get_time
+from app.utils.i18n import i18n
 from app.utils.url2txt import url_to_markdown
 from config.base_config import BASE_CHAT_API_KEY, BASE_CHAT_API_URL, BASE_CHAT_MODEL
 from config.logging_config import logger
@@ -178,7 +179,7 @@ def process_messages_stream(messages: list, search_mode: int = 1):
             if function_name == 'get_url_content':
                 json_args = json.loads(function_args)
                 for url in json_args['urls']:
-                    yield sse_create_openai_data(reasoning_content=f"我正在获取 {url} 网页的内容\n")
+                    yield sse_create_openai_data(reasoning_content=i18n('fetching_url', url=url))
                 function_output = registry.call(function_name, function_args)
                 messages[-1]['content'] = messages[-1]['content'] + f"现在的时间是{get_time()} 这是网页的内容 \n {function_output[:40000:]}"
 

--- a/app/search/fc_search.py
+++ b/app/search/fc_search.py
@@ -11,6 +11,7 @@ if str(ROOT_DIR) not in sys.path:
 from config.base_config import SEARCH_KEYWORD_MODEL, SEARCH_KEYWORD_API_KEY, SEARCH_KEYWORD_API_URL
 from config.logging_config import logger
 from app.utils.tools import format_urls, response2json, get_time, json2SearchRequests, format_search_plan
+from app.utils.i18n import i18n
 from app.utils.prompt import SEARCH_PROMPT
 from app.search.search_after_ai import search_ai
 
@@ -38,7 +39,7 @@ def search_core(messages: str, deep: bool = True):
         return search_results
 
 def search_tool(messages: str):
-    yield "🔍 **开始搜索...**\n\n"
+    yield i18n('search_start')
     messages = [{'role': 'user', 'content': SEARCH_PROMPT.substitute(messages=messages, current_time=get_time())}]
     logger.info("调用搜索工具")
     client = OpenAI(
@@ -60,7 +61,7 @@ def search_tool(messages: str):
     )
     
     if results is None:
-        yield "❌ **搜索关键词生成失败！**"
+        yield i18n('search_keyword_fail')
         return " "
     
     search_request = json2SearchRequests(results)
@@ -70,7 +71,7 @@ def search_tool(messages: str):
     if search_results and hasattr(search_results, 'get_urls') and search_results.get_urls():
         yield from format_urls(search_results.get_urls())
 
-    yield "✅ **搜索完成**\n"
+    yield i18n('search_done')
     yield f"results{search_results.to_str()}"
 
 

--- a/app/utils/i18n.py
+++ b/app/utils/i18n.py
@@ -1,0 +1,120 @@
+# Simple i18n support for fixed generator outputs
+from config.base_config import APP_LANG
+
+_MESSAGES = {
+    'start_deep_research': {
+        'zh': "🔍 **开始深度研究搜索...**\n\n",
+        'en': "🔍 **Start deep research search...**\n\n",
+    },
+    'initial_search': {
+        'zh': "📋 **初始搜索获取参考信息**\n",
+        'en': "📋 **Initial search to gather references**\n",
+    },
+    'initial_done': {
+        'zh': "✅ 初始搜索完成\n\n",
+        'en': "✅ Initial search complete\n\n",
+    },
+    'generate_first_plan': {
+        'zh': "📌 **生成第一个搜索计划**\n",
+        'en': "📌 **Generate first search plan**\n",
+    },
+    'first_plan_fail': {
+        'zh': "⚠️ 第一个搜索计划未能生成。\n\n",
+        'en': "⚠️ Failed to generate first search plan.\n\n",
+    },
+    'deep_end': {
+        'zh': "🏁 **深度研究结束**\n\n",
+        'en': "🏁 **Deep research finished**\n\n",
+    },
+    'exec_first_plan': {
+        'zh': "🔄 **执行第一个搜索计划**\n",
+        'en': "🔄 **Execute first search plan**\n",
+    },
+    'exec_plan': {
+        'zh': "🔄 **执行搜索计划{num}**\n",
+        'en': "🔄 **Execute search plan {num}**\n",
+    },
+    'plan_exec_done': {
+        'zh': "✅ 搜索计划{num}执行完成\n\n",
+        'en': "✅ Search plan {num} executed\n\n",
+    },
+    'plans_executed': {
+        'zh': "📊 **已执行的搜索计划数量：** {num}/{max}\n",
+        'en': "📊 **Executed search plans:** {num}/{max}\n",
+    },
+    'next_plan': {
+        'zh': "📌 **步骤{num}：生成下一个搜索计划**\n",
+        'en': "📌 **Step {num}: generate next search plan**\n",
+    },
+    'no_new_plan': {
+        'zh': "🏁 **未能生成新的搜索计划，信息获取完毕，深度研究提前完成**\n\n",
+        'en': "🏁 **No new plans generated, research finished early**\n\n",
+    },
+    'no_plan_executed': {
+        'zh': "🏁 **未能执行任何搜索计划，深度研究结束**\n\n",
+        'en': "🏁 **No search plans executed, research finished**\n\n",
+    },
+    'deep_finished': {
+        'zh': "🏁 **深度研究完成**\n\n",
+        'en': "🏁 **Deep research completed**\n\n",
+    },
+    'deep_search_done': {
+        'zh': "✅ **深度研究搜索完成**\n",
+        'en': "✅ **Deep research search done**\n",
+    },
+    'deep_error': {
+        'zh': "🚫 **研究过程出现意外,强行终止**",
+        'en': "🚫 **Unexpected error, research aborted**",
+    },
+    'search_start': {
+        'zh': "🔍 **开始搜索...**\n\n",
+        'en': "🔍 **Start searching...**\n\n",
+    },
+    'search_keyword_fail': {
+        'zh': "❌ **搜索关键词生成失败！**",
+        'en': "❌ **Failed to generate search keywords!**",
+    },
+    'search_done': {
+        'zh': "✅ **搜索完成**\n",
+        'en': "✅ **Search completed**\n",
+    },
+    'no_urls': {
+        'zh': "📝 **未查看任何网页内容**\n",
+        'en': "📝 **No page content viewed**\n",
+    },
+    'search_purpose': {
+        'zh': "🎯 **搜索预期：** {text}\n",
+        'en': "🎯 **Search purpose:** {text}\n",
+    },
+    'search_restrictions': {
+        'zh': "⭕ **结果限制：** {text}\n",
+        'en': "⭕ **Restrictions:** {text}\n",
+    },
+    'search_keywords': {
+        'zh': "🔍 **搜索关键词：**\n",
+        'en': "🔍 **Search keywords:**\n",
+    },
+    'viewed_urls': {
+        'zh': "🌐 **已查看 {num} 个网页：**\n",
+        'en': "🌐 **Viewed {num} pages:**\n",
+    },
+    'fetching_url': {
+        'zh': "我正在获取 {url} 网页的内容\n",
+        'en': "Fetching content of {url}\n",
+    },
+    'request_failed': {
+        'zh': "请求失败",
+        'en': "Request failed",
+    },
+}
+
+
+def i18n(key: str, **kwargs) -> str:
+    lang = APP_LANG if APP_LANG in ('zh', 'en') else 'zh'
+    msg = _MESSAGES.get(key, {}).get(lang, '')
+    if kwargs:
+        try:
+            msg = msg.format(**kwargs)
+        except Exception:
+            pass
+    return msg

--- a/app/utils/tools.py
+++ b/app/utils/tools.py
@@ -25,9 +25,10 @@ ROOT_DIR = Path(__file__).resolve().parent.parent.parent
 if str(ROOT_DIR) not in sys.path:
     sys.path.append(str(ROOT_DIR))
 
-from app.search.models import SearchRequest,QueryKeys
+from app.search.models import SearchRequest, QueryKeys
 from config.base_config import AVAILABLE_EXTENSIONS
 from config.logging_config import logger
+from app.utils.i18n import i18n
 
 def response2json(text: str, mode: str = "json_str") -> Union[Dict, List, None]:
     """
@@ -263,9 +264,9 @@ def format_search_plan(plan_info: dict):
     search_restrictions = plan_info.get('search_restrictions', '无')
     search_keywords = [item.get('keys', '') for item in plan_info.get('data', [])]
     
-    yield f"🎯 **搜索预期：** {search_purpose}\n"
-    yield f"⭕ **结果限制：** {search_restrictions}\n"
-    yield f"🔍 **搜索关键词：**\n"
+    yield i18n('search_purpose', text=search_purpose)
+    yield i18n('search_restrictions', text=search_restrictions)
+    yield i18n('search_keywords')
     
     for keyword in search_keywords:
         yield f"\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0\u00A0➤ {keyword}\n"
@@ -275,10 +276,10 @@ def format_urls(urls: List[str]):
     美化URL列表输出的生成器函数
     """
     if not urls:
-        yield "📝 **未查看任何网页内容**\n"
+        yield i18n('no_urls')
         return
     
-    yield f"🌐 **已查看 {len(urls)} 个网页：**\n"
+    yield i18n('viewed_urls', num=len(urls))
     
     for i, url in enumerate(urls, 1):
         if url:

--- a/config/base_config.py
+++ b/config/base_config.py
@@ -24,6 +24,9 @@ else:
     else:
         logger.error("未找到.env文件，也没有找到模板文件")
 
+# 应用语言，可通过 APP_LANG 环境变量设置，默认中文
+APP_LANG = os.getenv("APP_LANG", "zh").lower()
+
 
 def get_random_api_key(api_key_str):
     """从逗号分隔的API密钥字符串中随机选择一个


### PR DESCRIPTION
## Summary
- support language selection with `APP_LANG` env variable
- document `APP_LANG` in `.env.template`
- implement `i18n` helper with Chinese and English messages
- update generators to use `i18n` output

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_b_686947e9c748832a9889bc5c725cc458